### PR TITLE
Store * match in _ attribute.

### DIFF
--- a/src/common.coffee
+++ b/src/common.coffee
@@ -8,7 +8,15 @@ module.exports = common =
         results = regex.exec arg
 
         while results?
-            names.push results[1].slice(1) || '_'
+            name = results[1].slice(1)
+
+            if name == '_'
+              throw new TypeError(":_ can't be used as a pattern name in pattern #{arg}")
+
+            if names.indexOf(name) > -1
+              throw new TypeError("duplicate pattern name :#{name} in pattern #{arg}")
+
+            names.push name || '_'
             results = regex.exec arg
         names
 

--- a/src/url-pattern.coffee
+++ b/src/url-pattern.coffee
@@ -9,7 +9,14 @@ patternPrototype =
         return captured if @isRegex
 
         bound = {}
-        bound[@names[i]] = captured[i] for i in [0...captured.length]
+        for value, i in captured
+          name = @names[i]
+          if name == '_'
+            bound[name] = bound[name] || []
+            bound[name].push value
+          else
+            bound[name] = value
+
         bound
 
 module.exports = (arg) ->

--- a/test/url-pattern.coffee
+++ b/test/url-pattern.coffee
@@ -30,6 +30,16 @@ module.exports =
             test.deepEqual ['foo', 'bar', '_'], getNames '/foo/:foo/bar/:bar/baz/*'
             test.done()
 
+        'name _ is disallowed': (test) ->
+            test.throws ->
+              getNames '/foo/:_'
+            test.done()
+
+        'duplicate pattern names are disallowed': (test) ->
+            test.throws ->
+              getNames '/:foo/:foo'
+            test.done()
+
     'toRegexString':
 
         '^ and $ are added': (test) ->
@@ -91,17 +101,23 @@ module.exports =
         'prefix wildcard works': (test) ->
             pattern = newPattern '*/user/:userId'
             test.deepEqual pattern.match('/school/10/user/10'),
-              {_: '/school/10', userId: '10'}
+              {_: ['/school/10'], userId: '10'}
             test.done()
 
         'suffix wildcard works': (test) ->
             pattern = newPattern '/admin*'
             test.deepEqual pattern.match('/admin/school/10/user/10'),
-              {_: '/school/10/user/10'}
+              {_: ['/school/10/user/10']}
             test.done()
 
         'infix wildcard works': (test) ->
             pattern = newPattern '/admin/*/user/:userId'
             test.deepEqual pattern.match('/admin/school/10/user/10'),
-              {_: 'school/10', userId: '10'}
+              {_: ['school/10'], userId: '10'}
+            test.done()
+
+        'multiple wildcards works': (test) ->
+            pattern = newPattern '/admin/*/user/*/tail'
+            test.deepEqual pattern.match('/admin/school/10/user/10/12/tail'),
+              {_: ['school/10', '10/12']}
             test.done()


### PR DESCRIPTION
Hi, I use your library in https://github.com/andreypopp/react-router-component with a great success. For a new feature called "contextual routers" (a way to define nested routers hierarchies) I need to store a result of `*` matches.

This PR implements the needed change. What do you think about this?
