### PR TITLE
Remove paths to executables in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   },
   "main": "lib/url-pattern",
   "scripts": {
-    "compile": "node_modules/coffee-script/bin/coffee --bare --compile --output lib src",
+    "compile": "coffee --bare --compile --output lib src",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
-    "test": "node_modules/nodeunit/bin/nodeunit test/*.coffee"
+    "test": "nodeunit test/*.coffee"
   }
 }


### PR DESCRIPTION
You don't actually need to include the full path to executables in npm scripts, because npm adds them to the $PATH (as long as they are defined in package.json) -- take a look at http://blog.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/ for more info :)