### PR TITLE
match almost all unreserved characters without `.`

### DIFF
--- a/lib/url-pattern.js
+++ b/lib/url-pattern.js
@@ -16,7 +16,7 @@
   Compiler.prototype.escapeChar = '\\';
   Compiler.prototype.segmentNameStartChar = ':';
   Compiler.prototype.segmentNameCharset = 'a-zA-Z0-9';
-  Compiler.prototype.segmentValueCharset = 'a-zA-Z0-9-_ %';
+  Compiler.prototype.segmentValueCharset = 'a-zA-Z0-9-_~ %';
   Compiler.prototype.optionalSegmentStartChar = '(';
   Compiler.prototype.optionalSegmentEndChar = ')';
   Compiler.prototype.wildcardChar = '*';

--- a/src/url-pattern.coffee
+++ b/src/url-pattern.coffee
@@ -25,7 +25,7 @@
   Compiler.prototype.escapeChar = '\\'
   Compiler.prototype.segmentNameStartChar = ':'
   Compiler.prototype.segmentNameCharset = 'a-zA-Z0-9'
-  Compiler.prototype.segmentValueCharset = 'a-zA-Z0-9-_ %'
+  Compiler.prototype.segmentValueCharset = 'a-zA-Z0-9-_~ %'
   Compiler.prototype.optionalSegmentStartChar = '('
   Compiler.prototype.optionalSegmentEndChar = ')'
   Compiler.prototype.wildcardChar = '*'

--- a/test/url-pattern.coffee
+++ b/test/url-pattern.coffee
@@ -327,6 +327,10 @@ module.exports =
       _: ['school/10', '12/13']
       id: '10'
 
+    pattern = new UrlPattern '/user/:range'
+    test.deepEqual pattern.match('/user/10~20'),
+      range: '10~20'
+
     pattern = new UrlPattern '^admin^*^user^:id^*^tail'
     test.deepEqual pattern.match('^admin^school^10^user^10^12^13^tail'),
       _: ['school^10', '12^13']
@@ -413,7 +417,7 @@ module.exports =
 
   'match full stops in segment values': (test) ->
       compiler = new UrlPattern.Compiler()
-      compiler.segmentValueCharset = 'a-zA-Z0-9-_ %.'
+      compiler.segmentValueCharset = 'a-zA-Z0-9-_~ %.'
       pattern = new UrlPattern '/api/v1/user/:id/', compiler
       test.deepEqual pattern.match('/api/v1/user/test.name/'),
         id: 'test.name'


### PR DESCRIPTION
Match almost all unreserved characters without `.` in RFC 3986 and resolve #15.