### PR TITLE
Add "names" property to public api (incomplete, for discussion)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ interface UrlPatternOptions {
 }
 
 declare class UrlPattern {
+    names: string[];
+
     constructor(pattern: string, options?: UrlPatternOptions);
     constructor(pattern: RegExp, groupNames?: string[]);
 


### PR DESCRIPTION
How do you feel about making urlPatternInstance.names a part of the public API?  It helps my use case to know what parameter names are used in the pattern string.