### PR TITLE
docs: Fix simple typo, combosable -> composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pattern.stringify({id: 20}) // '/api/users/20'
 - [frequently asked questions](#frequently-asked-questions)
 - npm package: `npm install url-pattern`
 - bower package: `bower install url-pattern`
-- pattern parser implemented using simple, combosable, testable [parser combinators](https://en.wikipedia.org/wiki/Parser_combinator)
+- pattern parser implemented using simple, composable, testable [parser combinators](https://en.wikipedia.org/wiki/Parser_combinator)
 - [typescript typings](index.d.ts)
 
 [check out **passage** if you are looking for simple composable routing that builds on top of url-pattern](https://github.com/snd/passage)


### PR DESCRIPTION
There is a small typo in README.md.

Should read `composable` rather than `combosable`.

